### PR TITLE
fix: update reference to supabase official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About supabase-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/supabase-feedstock/blob/main/LICENSE.txt)
 
-Home: https://github.com/supabase-community/supabase-py
+Home: https://github.com/supabase/supabase-py
 
 Package license: MIT
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e8ade712b56919eb37724d4de90ee89f2d8f05393acb3e6470ab53ac95f9196e
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - supabase
 
 about:
-  home: https://github.com/supabase-community/supabase-py
+  home: https://github.com/supabase/supabase-py
   license: MIT
   license_family: MIT
   license_file: LICENSE


### PR DESCRIPTION
Version is unchanged. Supabase has decided to move Python from `supabase-community` to the official repo

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.